### PR TITLE
Support for multiple SCCM servers

### DIFF
--- a/cmloot.py
+++ b/cmloot.py
@@ -31,83 +31,13 @@ import os
 import re
 from io import BytesIO
 
-def main():
-    # Init the example's logger theme
-    logger.init()
-    print(version.BANNER)
-    parser = argparse.ArgumentParser(add_help = True, description = "SMB client implementation.")
-
-    parser.add_argument('target', action='store', help='[[domain/]username[:password]@]<targetName or address>')
-    parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
-    
-    group = parser.add_argument_group('cmloot')
-    group.add_argument('-cmlootinventory', default="sccmfiles.txt", action='store', help='File to store all indexed filepaths found in DataLib folder. Default: sccmfiles.txt', metavar = "sccmfiles.txt")
-    group.add_argument('-cmlootdownload', action='store', help='Start downloading files from inventory file. Ex: -cmlootdownload sccmfiles.txt', metavar = "sccmfiles.txt")
-    group.add_argument('-extensions', type=str, default=["XML","INI","CONFIG"], nargs='*',  help='Files to download from inventory file. Default: -extensions XML INI CONFIG')
-
-    group = parser.add_argument_group('authentication')
-
-    group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
-    group.add_argument('-no-pass', action="store_true", help='don\'t ask for password (useful for -k)')
-    group.add_argument('-k', action="store_true", help='Use Kerberos authentication. Grabs credentials from ccache file '
-                                                       '(KRB5CCNAME) based on target parameters. If valid credentials '
-                                                       'cannot be found, it will use the ones specified in the command '
-                                                       'line')
-    group.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key to use for Kerberos Authentication '
-                                                                            '(128 or 256 bits)')
-
-    group = parser.add_argument_group('connection')
-
-    group.add_argument('-dc-ip', action='store', metavar="ip address",
-                       help='IP Address of the domain controller. If omitted it will use the domain part (FQDN) specified in '
-                            'the target parameter')
-    group.add_argument('-target-ip', action='store', metavar="ip address",
-                       help='IP Address of the target machine. If omitted it will use whatever was specified as target. '
-                            'This is useful when target is the NetBIOS name and you cannot resolve it')
-    group.add_argument('-port', choices=['139', '445'], nargs='?', default='445', metavar="destination port",
-                       help='Destination port to connect to SMB Server')
-
-    if len(sys.argv)==1:
-        parser.print_help()
-        sys.exit(1)
-
-    options = parser.parse_args()
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
-
-    domain, username, password, address = parse_target(options.target)
-
-    if options.target_ip is None:
-        options.target_ip = address
-
-    if domain is None:
-        domain = ''
-
-    if password == '' and username != '' and options.hashes is None and options.no_pass is False and options.aesKey is None:
-        from getpass import getpass
-        password = getpass("Password:")
-
-    if options.aesKey is not None:
-        options.k = True
-
-    if options.hashes is not None:
-        lmhash, nthash = options.hashes.split(':')
-    else:
-        lmhash = ''
-        nthash = ''
-
+def connect_to_sccm(address, username, password, domain, lmhash, nthash, options, appendToInv):
     try:
         smbClient = SMBConnection(address, options.target_ip, sess_port=int(options.port))
         if options.k is True:
             smbClient.kerberosLogin(username, password, domain, lmhash, nthash, options.aesKey, options.dc_ip )
         else:
             smbClient.login(username, password, domain, lmhash, nthash)
-        
         try:
             def get_files_in_folder(targetfolder):
                 files = []
@@ -134,9 +64,11 @@ def main():
                 outfile.write(filepath)
             
             def create_inventory():
-                if os.path.exists(inventory_file):
+                if os.path.exists(inventory_file) and not appendToInv:
                     print("[+]", inventory_file, "exists. Remove it if you want to recreate the inventory.")
                     return
+                elif os.path.exists(inventory_file) and not appendToInv:
+                    print("[+]", inventory_file, "exists. Appending to it.")
 
 
                 # test connection
@@ -210,7 +142,7 @@ def main():
                         print("[+] Already downloaded", hashvalue[0:4] + "-" + downloadlist[hashvalue])
 
             inventory_file = options.cmlootinventory
-            if not options.cmlootdownload:
+            if options.cmlootinventory:
                 create_inventory()
             if options.cmlootdownload:
                 downloadfiles()
@@ -226,6 +158,97 @@ def main():
             import traceback
             traceback.print_exc()
         logging.error(str(e))
+
+def main():
+    # Init the example's logger theme
+    logger.init()
+    print(version.BANNER)
+    parser = argparse.ArgumentParser(add_help = True, description = "SMB client implementation.")
+
+    parser.add_argument('target', action='store', help='[[domain/]username[:password]@]<targetName or address>')
+    parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    
+    group = parser.add_argument_group('cmloot')
+    group.add_argument('-cmlootinventory', default="sccmfiles.txt", action='store', help='File to store all indexed filepaths found in DataLib folder. Default: sccmfiles.txt', metavar = "sccmfiles.txt")
+    group.add_argument('-cmlootdownload', action='store', help='Start downloading files from inventory file. Ex: -cmlootdownload sccmfiles.txt', metavar = "sccmfiles.txt")
+    group.add_argument('-extensions', type=str, default=["XML","INI","CONFIG"], nargs='*',  help='Files to download from inventory file. Default: -extensions XML INI CONFIG')
+
+    group = parser.add_argument_group('authentication')
+
+    group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
+    group.add_argument('-no-pass', action="store_true", help='don\'t ask for password (useful for -k)')
+    group.add_argument('-k', action="store_true", help='Use Kerberos authentication. Grabs credentials from ccache file '
+                                                       '(KRB5CCNAME) based on target parameters. If valid credentials '
+                                                       'cannot be found, it will use the ones specified in the command '
+                                                       'line')
+    group.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key to use for Kerberos Authentication '
+                                                                            '(128 or 256 bits)')
+
+    group = parser.add_argument_group('connection')
+
+    group.add_argument('-dc-ip', action='store', metavar="ip address",
+                       help='IP Address of the domain controller. If omitted it will use the domain part (FQDN) specified in '
+                            'the target parameter')
+    group.add_argument('-target-ip', action='store', metavar="ip address",
+                       help='IP Address of the target machine. If omitted it will use whatever was specified as target. '
+                            'This is useful when target is the NetBIOS name and you cannot resolve it')
+    group.add_argument('-port', choices=['139', '445'], nargs='?', default='445', metavar="destination port",
+                       help='Destination port to connect to SMB Server')
+    group.add_argument('-target-file', action='store', metavar="target file",
+                       help='File with specifies one target (host) per line. If omitted it will use whatever was specified as target. ')
+
+    if len(sys.argv)==1:
+        parser.print_help()
+        sys.exit(1)
+
+    options = parser.parse_args()
+
+    if options.debug is True:
+        logging.getLogger().setLevel(logging.DEBUG)
+        # Print the Library's installation path
+        logging.debug(version.getInstallationPath())
+    else:
+        logging.getLogger().setLevel(logging.INFO)
+
+    domain, username, password, address = parse_target(options.target)
+
+    if options.target_ip is None:
+        options.target_ip = address
+
+    if domain is None:
+        domain = ''
+
+    if password == '' and username != '' and options.hashes is None and options.no_pass is False and options.aesKey is None:
+        from getpass import getpass
+        password = getpass("Password:")
+
+    if options.aesKey is not None:
+        options.k = True
+
+    if options.hashes is not None:
+        lmhash, nthash = options.hashes.split(':')
+    else:
+        lmhash = ''
+        nthash = ''
+    
+    if options.target_file:
+        try:
+            targets = open(options.target_file, 'r').readlines()
+        except Exception as e:
+            if logging.getLogger().level == logging.DEBUG:
+                import traceback
+                traceback.print_exc()
+            logging.error(str(e))
+        print("[+] Found", len(targets), "targets.")
+        for t in targets:
+            t = t.replace("\r", "").replace("\n", "").strip()
+            print("[+] Using target", t, ".")
+            address = t
+            connect_to_sccm(address, username, password, domain, lmhash, nthash, options, True)
+    else:
+        connect_to_sccm(address, username, password, domain, lmhash, nthash, options, False)
+
+    
 
 if __name__ == "__main__":
     main()

--- a/cmloot.py
+++ b/cmloot.py
@@ -67,7 +67,7 @@ def connect_to_sccm(address, username, password, domain, lmhash, nthash, options
                 if os.path.exists(inventory_file) and not appendToInv:
                     print("[+]", inventory_file, "exists. Remove it if you want to recreate the inventory.")
                     return
-                elif os.path.exists(inventory_file) and not appendToInv:
+                elif os.path.exists(inventory_file) and appendToInv:
                     print("[+]", inventory_file, "exists. Appending to it.")
 
 


### PR DESCRIPTION
Hi!

I added -target-file, so you can specify multiple SCCM servers in a txt file. This enables to create the inventory and to download the files automatically from these servers.

I also changed the if / else part so that you can create the inventory file and download the files afterwards without starting the tool again.