### PR TITLE
file download error handling

### DIFF
--- a/cmloot.py
+++ b/cmloot.py
@@ -137,16 +137,19 @@ def connect_to_sccm(address, username, password, domain, lmhash, nthash, options
                                 share = "\\" + share
                                 share = share + ".INI"
                                 # openfile to get Hash
-                                f = BytesIO()
-                                smbClient.getFile("SCCMContentLib$", share, f.write) #, sys.stdout.buffer.write))
-                                content = f.getvalue().decode()
-                                #regexp to extract hash
-                                hashvalue = re.search("Hash[^=]*=([A-Z0-9]+)",content)
-                                hashvalue = hashvalue.group(1)
-                                # create downloadlist tuple <filename>, <hash>
-                                filename = share.split('\\')[-1]
-                                filename = filename.strip('.INI')
-                                downloadlist[hashvalue] = filename
+                                try:
+                                    f = BytesIO()
+                                    smbClient.getFile("SCCMContentLib$", share, f.write) #, sys.stdout.buffer.write))
+                                    content = f.getvalue().decode()
+                                    #regexp to extract hash
+                                    hashvalue = re.search("Hash[^=]*=([A-Z0-9]+)",content)
+                                    hashvalue = hashvalue.group(1)
+                                    # create downloadlist tuple <filename>, <hash>
+                                    filename = share.split('\\')[-1]
+                                    filename = filename.strip('.INI')
+                                    downloadlist[hashvalue] = filename
+                                except Exception as e:
+                                    print(f"[-] Error processing {share}: {e}")
                 #print(downloadlist)
 
                 for hashvalue in downloadlist.keys():


### PR DESCRIPTION
Hello,

I have fixed a small issue with downloading files via SMB.
 
Before: If an error occurred on one of the files (deleted, does not exist on the target DP), the entire script would stop.
Now: In case of an error, the script will continue to process the other inputs in the cmlootdownload file.